### PR TITLE
Moved the self-auth'ing mechanism to be done by the salt reactor 

### DIFF
--- a/mariadb_stack.yaml
+++ b/mariadb_stack.yaml
@@ -256,7 +256,7 @@ resources:
         while read -r line
         do
             if [ -n "$line" ]; then
-                git clone -b cantu-reactor $line
+                git clone $line
             fi
         done <<< "$state_repos"
 

--- a/mariadb_stack.yaml
+++ b/mariadb_stack.yaml
@@ -136,6 +136,10 @@ resources:
       - protocol: tcp
         port_range_min: 4444
         port_range_max: 4444
+        remote_ip_prefix:
+          get_attr:
+            - subnet
+            - cidr
 
   # Keypair for communicating between nodes within the stack.
   # Will allow minions to ssh into the master and vice versa.
@@ -289,28 +293,7 @@ resources:
         # Install salt minion
         curl -L http://bootstrap.saltstack.org | sh -s -- git v2014.7.1
         echo master: $master >> /etc/salt/minion
-
         service salt-minion restart
-
-        # ssh-keyscan -H $master >> /root/.ssh/known_hosts
-
-        # MASTER_PKI_PATH="/etc/salt/pki/master/minions/"
-        # MASTER_PKI_PATH_PRE="/etc/salt/pki/master/minions_pre/"
-        # MINION_PKI_PATH="/etc/salt/pki/minion/minion.pub"
-        # HOSTNAME="$(python  -c 'import socket; print socket.getfqdn()')"
-
-        # while [ ! -s ${MINION_PKI_PATH} ]; do
-        #     echo "Waiting for ${MINION_PKI_PATH} to have non-zero content."
-        #     sleep 2
-        # done
-
-        # cp $MINION_PKI_PATH /root/minion_key
-
-        # scp -i /root/.ssh/coms_rsa /root/minion_key root@$master:/tmp/$HOSTNAME
-
-        # ssh -i /root/.ssh/coms_rsa root@$master "mv /tmp/$HOSTNAME $MASTER_PKI_PATH$HOSTNAME; chmod 700 $MASTER_PKI_PATH$HOSTNAME; rm $MASTER_PKI_PATH_PRE$HOSTNAME"
-
-        #rm /root/minion_key
         rm /root/.ssh/coms_rsa
         /sbin/ifconfig -a | /usr/bin/awk '/eth.*Ethernet/ {print $1}' | while read E; do /usr/bin/sudo /sbin/dhclient $E; done
         touch ${prefix}.ran
@@ -327,7 +310,8 @@ resources:
             - coms
             - public_key
         state_repos: |
-          https://github.com/elextro/galera
+          https://github.com/rcbops/galera
+          https://github.com/rcbops/base-hardening-formula
       config:
         get_resource: config-salt-master
       server:
@@ -808,7 +792,7 @@ resources:
         salt '*' saltutil.refresh_pillar
         salt '*' mine.update
         salt-run state.sls orchestration.galera_cluster
-        #salt '*' state.sls base-hardening-formula.base-hardening-formula
+        salt '*' state.sls base-hardening-formula.base-hardening-formula
         touch ${prefix}.ran
 
   # Deploys the the deploy softwareconfig

--- a/mariadb_stack.yaml
+++ b/mariadb_stack.yaml
@@ -230,12 +230,13 @@ resources:
 
         # Install salt master
         echo "Install Salt Master"
-        curl -L http://bootstrap.saltstack.org | sh -s -- -M -N git v2014.1.13
+        curl -L http://bootstrap.saltstack.org | sh -s -- -M -N git v2014.7.1
         mkdir -p /srv/salt
         mkdir -p /srv/salt/orchestration
         mkdir -p /srv/pillar
         mkdir -p /srv/pillar/galera
         mkdir -p /srv/pillar/haproxy
+        mkdir -p /srv/reactor
         echo -e 'file_roots:\n  base:\n    - /srv/salt' >> /etc/salt/master
 
         # Clone state/formula repos in state root directory
@@ -243,7 +244,7 @@ resources:
         while read -r line
         do
             if [ -n "$line" ]; then
-                git clone $line
+                git clone -b cantu-reactor $line
             fi
         done <<< "$state_repos"
 
@@ -278,31 +279,30 @@ resources:
         echo "$public_key" >> /root/.ssh/authorized_keys
 
         # Install salt minion
-        curl -L http://bootstrap.saltstack.org | sh -s -- git v2014.1.13
+        curl -L http://bootstrap.saltstack.org | sh -s -- git v2014.7.1
         echo master: $master >> /etc/salt/minion
 
         service salt-minion restart
 
-        ssh-keyscan -H $master >> /root/.ssh/known_hosts
+        # ssh-keyscan -H $master >> /root/.ssh/known_hosts
 
-        MASTER_PKI_PATH="/etc/salt/pki/master/minions/"
-        MASTER_PKI_PATH_PRE="/etc/salt/pki/master/minions_pre/"
-        MINION_PKI_PATH="/etc/salt/pki/minion/minion.pub"
-        HOSTNAME="$(python  -c 'import socket; print socket.getfqdn()')"
+        # MASTER_PKI_PATH="/etc/salt/pki/master/minions/"
+        # MASTER_PKI_PATH_PRE="/etc/salt/pki/master/minions_pre/"
+        # MINION_PKI_PATH="/etc/salt/pki/minion/minion.pub"
+        # HOSTNAME="$(python  -c 'import socket; print socket.getfqdn()')"
 
-        while [ ! -s ${MINION_PKI_PATH} ]; do
-            echo "Waiting for ${MINION_PKI_PATH} to have non-zero content."
-            sleep 2
-        done
+        # while [ ! -s ${MINION_PKI_PATH} ]; do
+        #     echo "Waiting for ${MINION_PKI_PATH} to have non-zero content."
+        #     sleep 2
+        # done
 
-        cp $MINION_PKI_PATH /root/minion_key
+        # cp $MINION_PKI_PATH /root/minion_key
 
-        scp -i /root/.ssh/coms_rsa /root/minion_key root@$master:/tmp/$HOSTNAME
+        # scp -i /root/.ssh/coms_rsa /root/minion_key root@$master:/tmp/$HOSTNAME
 
-        ssh -i /root/.ssh/coms_rsa root@$master "mv /tmp/$HOSTNAME $MASTER_PKI_PATH$HOSTNAME; chmod 700 $MASTER_PKI_PATH$HOSTNAME; rm $MASTER_PKI_PATH_PRE$HOSTNAME"
+        # ssh -i /root/.ssh/coms_rsa root@$master "mv /tmp/$HOSTNAME $MASTER_PKI_PATH$HOSTNAME; chmod 700 $MASTER_PKI_PATH$HOSTNAME; rm $MASTER_PKI_PATH_PRE$HOSTNAME"
 
-        service salt-minion restart
-        rm /root/minion_key
+        #rm /root/minion_key
         rm /root/.ssh/coms_rsa
         /sbin/ifconfig -a | /usr/bin/awk '/eth.*Ethernet/ {print $1}' | while read E; do /usr/bin/sudo /sbin/dhclient $E; done
         touch ${prefix}.ran
@@ -319,8 +319,7 @@ resources:
             - coms
             - public_key
         state_repos: |
-          https://github.com/rcbops/galera
-          https://github.com/rcbops/base-hardening-formula
+          https://github.com/elextro/galera
       config:
         get_resource: config-salt-master
       server:
@@ -354,6 +353,17 @@ resources:
             - coms
             - private_key
 
+        /etc/salt/master.d/reactor.conf: |
+          reactor:
+            - 'salt/auth':
+              - /srv/reactor/auth-pending.sls
+
+        /srv/reactor/auth-pending.sls: |
+          {% if 'act' in data and data['act'] == 'pend' and data['id'].startswith('galera') %}
+          minion_add:
+            wheel.key.accept
+            - match: {{ data['id'] }}
+          {% endif %}
         #The top.sls file for salt states.
         #Dictates which minions get which formulas
         /srv/salt/orchestration/galera_cluster.sls: |
@@ -362,7 +372,7 @@ resources:
               - tgt: 'roles:haproxy'
               - tgt_type: grain
               - sls:
-                - galera.haproxy
+                - galera.haproxy-setup
                 - galera.mysql
           setup:
             salt.state:
@@ -374,21 +384,21 @@ resources:
               - tgt: 'roles:db_bootstrap'
               - tgt_type: grain
               - sls:
-                - galera.stop
+                - galera.stop-mysql
               - requires:
                 - salt: setup
           db2-stop:
             salt.state:
               - tgt: '*db2*'
               - sls:
-                - galera.stop
+                - galera.stop-mysql
               - requires:
                 - salt: bootstrap-stop
           db3-stop:
             salt.state:
               - tgt: '*db3*'
               - sls:
-                - galera.stop
+                - galera.stop-mysql
               - requires:
                 - salt: db2-stop
           bootstrap-start:
@@ -396,7 +406,7 @@ resources:
               - tgt: 'roles:db_bootstrap'
               - tgt_type: grain
               - sls:
-                - galera.start
+                - galera.start-mysql
               - requires:
                 - salt: db3-stop
           non-bootstrap-start:
@@ -404,7 +414,7 @@ resources:
               - tgt: 'roles:db'
               - tgt_type: grain
               - sls:
-                - galera.start
+                - galera.start-mysql
               - require:
                 - salt: bootstrap-start
           build-db:
@@ -412,7 +422,7 @@ resources:
               - tgt: 'roles:db_bootstrap'
               - tgt_type: grain
               - sls:
-                - galera.db
+                - galera.build-db
               - require:
                 - salt: non-bootstrap-start
 
@@ -495,8 +505,6 @@ resources:
                   chain: INPUT
                   proto: tcp
                   dport: 13306
-
-
             params:
               $user:
                 get_param: db-username
@@ -792,7 +800,7 @@ resources:
         salt '*' saltutil.refresh_pillar
         salt '*' mine.update
         salt-run state.sls orchestration.galera_cluster
-        salt '*' state.sls base-hardening-formula.base-hardening-formula
+        #salt '*' state.sls base-hardening-formula.base-hardening-formula
         touch ${prefix}.ran
 
   # Deploys the the deploy softwareconfig

--- a/mariadb_stack.yaml
+++ b/mariadb_stack.yaml
@@ -122,9 +122,17 @@ resources:
       - protocol: tcp
         port_range_min: 4505
         port_range_max: 4506
+        remote_ip_prefix:
+          get_attr:
+            - subnet
+            - cidr
       - protocol: tcp
         port_range_min: 4567
         port_range_max: 4568
+        remote_ip_prefix:
+          get_attr:
+            - subnet
+            - cidr
       - protocol: tcp
         port_range_min: 4444
         port_range_max: 4444
@@ -361,8 +369,8 @@ resources:
         /srv/reactor/auth-pending.sls: |
           {% if 'act' in data and data['act'] == 'pend' and data['id'].startswith('galera') %}
           minion_add:
-            wheel.key.accept
-            - match: {{ data['id'] }}
+            wheel.key.accept:
+              - match: {{ data['id'] }}
           {% endif %}
         #The top.sls file for salt states.
         #Dictates which minions get which formulas


### PR DESCRIPTION
This PR does a few things: 
* Added reactor config files and state.sls files to the master. These config files allow for self-auth of minions that 1) have a hostname that starts with 'galera' and 2) are in the same network as the salt-master. 
* Changed the names of the state.sls files to match the new naming convention in the galera formulas. 
* Restricted salt traffic to only be accepted from the master's corresponding tenant network. This is so minions can't self-auth to the master using it's floating-ip. 
* Updated salt version to 2014.7.1

These changes were made with the view of making it easier to implement a scaling mechanism. We can also now take advantage of the salt reactor system. 
http://docs.saltstack.com/en/latest/topics/reactor/

MUST BE MERGED WITH:
https://github.com/rcbops/galera/pull/6
