### PR TITLE
Reduced personality files to 5

### DIFF
--- a/mariadb_stack.yaml
+++ b/mariadb_stack.yaml
@@ -356,68 +356,6 @@ resources:
             wheel.key.accept:
               - match: {{ data['id'] }}
           {% endif %}
-        #The top.sls file for salt states.
-        #Dictates which minions get which formulas
-        /srv/salt/orchestration/galera_cluster.sls: |
-          haproxy:
-            salt.state:
-              - tgt: 'roles:haproxy'
-              - tgt_type: grain
-              - sls:
-                - galera.haproxy-setup
-                - galera.mysql
-          setup:
-            salt.state:
-              - tgt: '*db*'
-              - sls:
-                - galera
-          bootstrap-stop:
-            salt.state:
-              - tgt: 'roles:db_bootstrap'
-              - tgt_type: grain
-              - sls:
-                - galera.stop-mysql
-              - requires:
-                - salt: setup
-          db2-stop:
-            salt.state:
-              - tgt: '*db2*'
-              - sls:
-                - galera.stop-mysql
-              - requires:
-                - salt: bootstrap-stop
-          db3-stop:
-            salt.state:
-              - tgt: '*db3*'
-              - sls:
-                - galera.stop-mysql
-              - requires:
-                - salt: db2-stop
-          bootstrap-start:
-            salt.state:
-              - tgt: 'roles:db_bootstrap'
-              - tgt_type: grain
-              - sls:
-                - galera.start-mysql
-              - requires:
-                - salt: db3-stop
-          non-bootstrap-start:
-            salt.state:
-              - tgt: 'roles:db'
-              - tgt_type: grain
-              - sls:
-                - galera.start-mysql
-              - require:
-                - salt: bootstrap-start
-          build-db:
-            salt.state:
-              - tgt: 'roles:db_bootstrap'
-              - tgt_type: grain
-              - sls:
-                - galera.build-db
-              - require:
-                - salt: non-bootstrap-start
-
 
         #The top.sls file for salt pillars
         #Dictates which minions get which pillars.
@@ -791,7 +729,7 @@ resources:
         [ -e ${prefix}.ran ] && exit 0
         salt '*' saltutil.refresh_pillar
         salt '*' mine.update
-        salt-run state.sls orchestration.galera_cluster
+        salt-run state.sls galera.orchestration.galera_cluster
         salt '*' state.sls base-hardening-formula.base-hardening-formula
         touch ${prefix}.ran
 


### PR DESCRIPTION
This reduces the number of personality files used on the salt-master, removing the requirement for the user to change the default number of allowed injected files. The orchestration runner was moved to the salt formula. 